### PR TITLE
Se añade el uso de IP a los términos y condiciones

### DIFF
--- a/src/app/components/terms/terms.component.html
+++ b/src/app/components/terms/terms.component.html
@@ -117,6 +117,9 @@
                     No usamos software publicitario ni entidades de terceros que los usen.
                 </li>
                 <li class="mt-2">
+                    Se usará la IP de cada usuario solamente con los fines de mostrar el número de visitas en los itinerarios y puntos de interés y para evitar fraudes.
+                </li>
+                <li class="mt-2">
                     Para representar los mapas, se usará el servicio de mapas gestionado por Here Inc., y se enviará por
                     tanto las coordenadas relacionadas con un itinerario creado. <a
                         href="https://legal.here.com/es-es/terms">Más información</a>


### PR DESCRIPTION
Se añade dentro de la sección de "Tratamiento de datos" asociada a "Términos y condiciones" el apartado: "Se usará la IP de cada usuario solamente con los fines de mostrar el número de visitas en los itinerarios y puntos de interés y para evitar fraudes."

Tarea relacionada #142